### PR TITLE
Add .isStreaming() support to safenet

### DIFF
--- a/SafeNet/safeNet.lua
+++ b/SafeNet/safeNet.lua
@@ -63,6 +63,8 @@ local streaming = false
 local canceling = false
 local cancelQueue = false
 
+function safeNet.isStreaming() return streaming end
+
 function safeNet.setTimeout(newTimeout) timeout = newTimeout end
 
 -- Sets the bytes per second cap


### PR DESCRIPTION
Adds .isStreaming() support similar to https://thegrb93.github.io/StarfallEx/#Libraries.net.isStreaming. Will return true when safeNet is actively streaming, useful if you want to know if there's a queue or not.